### PR TITLE
[FIX] 검증 수정,통일

### DIFF
--- a/src/main/java/com/umc/DutchTogether/domain/meeting/controller/MeetingRestController.java
+++ b/src/main/java/com/umc/DutchTogether/domain/meeting/controller/MeetingRestController.java
@@ -6,11 +6,14 @@ import com.umc.DutchTogether.domain.meeting.dto.MeetingResponse;
 import com.umc.DutchTogether.domain.meeting.entity.Meeting;
 import com.umc.DutchTogether.domain.meeting.service.MeetingCommandService;
 import com.umc.DutchTogether.domain.meeting.service.MeetingQueryService;
+import com.umc.DutchTogether.global.validation.annotation.ExistMeeting;
 import com.umc.DutchTogether.global.apiPayload.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+@Validated
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/meetings")
@@ -20,14 +23,14 @@ public class MeetingRestController {
     private final MeetingQueryService meetingQueryService;
 
     @PostMapping("/")
-    public ApiResponse<MeetingResponse.MeetingDT0> createMeeting(@RequestBody @Valid MeetingRequest.MeetingDT0 request){
+    public ApiResponse<MeetingResponse.MeetingDT0> createMeeting(@Valid @RequestBody MeetingRequest.MeetingDT0 request){
         Meeting meeting = meetingCommandService.createMeeting(request);
         return ApiResponse.onSuccess(MeetingConverter.toMeetingResultDTD(meeting));
     }
 
     @GetMapping("/{meetingNum}/link")
-    public ApiResponse<String> getMeetingLink(@PathVariable Long meetingNum) {
-        String meetingLink = meetingQueryService.getMeetingLink(meetingNum);
-        return ApiResponse.onSuccess(meetingLink);
+    public ApiResponse<MeetingResponse.MeetingLinkResultDT0> getMeetingLink(@ExistMeeting @PathVariable Long meetingNum) {
+        Meeting meeting = meetingQueryService.getMeeting(meetingNum);
+        return ApiResponse.onSuccess(MeetingConverter.toMeetingLinkResultDTD(meeting));
     }
 }

--- a/src/main/java/com/umc/DutchTogether/domain/meeting/converter/MeetingConverter.java
+++ b/src/main/java/com/umc/DutchTogether/domain/meeting/converter/MeetingConverter.java
@@ -22,4 +22,13 @@ public class MeetingConverter {
                 .meetingNum(meeting.getId())
                 .build();
     }
+
+    public static MeetingResponse.MeetingLinkResultDT0 toMeetingLinkResultDTD(Meeting meeting) {
+        if (meeting == null) {
+            return null;
+        }
+        return MeetingResponse.MeetingLinkResultDT0.builder()
+                .meetingLink(meeting.getLink())
+                .build();
+    }
 }

--- a/src/main/java/com/umc/DutchTogether/domain/meeting/dto/MeetingRequest.java
+++ b/src/main/java/com/umc/DutchTogether/domain/meeting/dto/MeetingRequest.java
@@ -1,7 +1,7 @@
 package com.umc.DutchTogether.domain.meeting.dto;
 
-import com.umc.DutchTogether.domain.meeting.validation.annotation.ExistMeeting;
-import com.umc.DutchTogether.domain.meeting.validation.annotation.ValidatePassword;
+import com.umc.DutchTogether.global.validation.annotation.ValidateMeeting;
+import com.umc.DutchTogether.global.validation.annotation.ValidatePassword;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -15,7 +15,7 @@ public class MeetingRequest {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    @ExistMeeting
+    @ValidateMeeting
     @Schema(title = "모임 생성 요청 DTO")
     public static class MeetingDT0{
         private String meetingId;
@@ -24,15 +24,4 @@ public class MeetingRequest {
         @NotNull(message = "모임 이름을 입력해주세요")
         private String name;
     }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @ExistMeeting
-    @Schema(title = "모임 링크 조회 요청 DTO")
-    public static class MeetingLinkDT0{
-        private Long meetingNum;
-    }
-
 }

--- a/src/main/java/com/umc/DutchTogether/domain/meeting/service/MeetingQueryService.java
+++ b/src/main/java/com/umc/DutchTogether/domain/meeting/service/MeetingQueryService.java
@@ -1,6 +1,10 @@
 package com.umc.DutchTogether.domain.meeting.service;
 
+import com.umc.DutchTogether.domain.meeting.entity.Meeting;
+
+import java.util.Optional;
+
 public interface MeetingQueryService {
-    public String getMeetingLink(Long meetingNum);
+    public Meeting getMeeting(Long meetingNum);
 
 }

--- a/src/main/java/com/umc/DutchTogether/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/umc/DutchTogether/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -17,9 +19,7 @@ public class MeetingQueryServiceImpl implements MeetingQueryService{
     private final MeetingRepository meetingRepository;
 
     @Override
-    public String getMeetingLink(Long meetingNum) {
-        Meeting meeting = meetingRepository.findById(meetingNum)
-                .orElseThrow(() -> new MeetingHandler(ErrorStatus.MEETING_NOT_FOUND));
-        return meeting.getLink();
+    public Meeting getMeeting(Long meetingNum) {
+        return meetingRepository.findById(meetingNum).orElse(null);
     }
 }

--- a/src/main/java/com/umc/DutchTogether/domain/settlement/controller/SettlementRestController.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlement/controller/SettlementRestController.java
@@ -3,8 +3,10 @@ package com.umc.DutchTogether.domain.settlement.controller;
 import com.umc.DutchTogether.domain.settlement.dto.*;
 import com.umc.DutchTogether.domain.settlement.service.SettlementCommandService;
 import com.umc.DutchTogether.global.apiPayload.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -14,7 +16,6 @@ public class SettlementRestController {
 
 
     private final SettlementCommandService settlementCommandService;
-
     //    @PostMapping("/single")
 //    @ResponseStatus(HttpStatus.OK)
 //    public Object createSingleSettlement(@Validated @RequestBody SingleSettlementCreateRequestDto request, BindingResult bindingResult) {
@@ -32,7 +33,7 @@ public class SettlementRestController {
 //    }
 
     @PostMapping("/single")
-    public ApiResponse<SettlementResponse.SettlementDTO> createSingleSettlement(@RequestBody SettlementRequest.SettlementDTO request) {
+    public ApiResponse<SettlementResponse.SettlementDTO> createSingleSettlement(@RequestBody @Valid SettlementRequest.SettlementDTO request) {
         SettlementResponse.SettlementDTO settlement = settlementCommandService.CreateSingleSettlement(request);
         return ApiResponse.onSuccess(settlement);
     }

--- a/src/main/java/com/umc/DutchTogether/domain/settlement/dto/SettlementRequest.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlement/dto/SettlementRequest.java
@@ -1,5 +1,6 @@
 package com.umc.DutchTogether.domain.settlement.dto;
 
+import com.umc.DutchTogether.global.validation.annotation.ExistMeeting;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
@@ -17,6 +18,7 @@ public class SettlementRequest {
 
         @NotNull(message = "모임 번호를 요청에 포함해주세요.")
         @Min(value = 0, message = "모임 번호는 음수일 수 없습니다.")
+        @ExistMeeting
         private Long meetingNum;
 
         @NotNull(message = "은행 이름을 입력해주세요.")

--- a/src/main/java/com/umc/DutchTogether/domain/settlement/service/SettlementCommandServiceImpl.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlement/service/SettlementCommandServiceImpl.java
@@ -15,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -26,8 +28,7 @@ public class SettlementCommandServiceImpl implements SettlementCommandService {
     @Override
 
     public SettlementResponse.SettlementDTO CreateSingleSettlement(SettlementRequest.SettlementDTO request) {
-        Meeting meeting = meetingRepository.findById(request.getMeetingNum())
-                .orElseThrow(() -> new SettlementHandler(ErrorStatus.SETTLEMENT_NOT_FOUND_ID));
+        Optional<Meeting> meeting = meetingRepository.findById(request.getMeetingNum());
 
         // 결제자 저장
         Payer payer = Payer.builder()
@@ -36,7 +37,7 @@ public class SettlementCommandServiceImpl implements SettlementCommandService {
                 .bank(request.getBankName())
                 .build();
         Settlement settlement = Settlement.builder()
-                .meeting(meeting)
+                .meeting(meeting.get())
                 .payer(payer)
                 .totalAmount(request.getTotalAmount())
                 .numPeople(request.getNumPeople())

--- a/src/main/java/com/umc/DutchTogether/global/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/umc/DutchTogether/global/apiPayload/exception/ExceptionAdvice.java
@@ -6,6 +6,7 @@ import com.umc.DutchTogether.global.apiPayload.code.status.ErrorStatus;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,13 +25,21 @@ import java.util.Optional;
 @RestControllerAdvice(annotations = {RestController.class})
 public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
+    private final ConfigurationPropertiesAutoConfiguration configurationPropertiesAutoConfiguration;
+
+    public ExceptionAdvice(ConfigurationPropertiesAutoConfiguration configurationPropertiesAutoConfiguration) {
+        this.configurationPropertiesAutoConfiguration = configurationPropertiesAutoConfiguration;
+    }
+
     @org.springframework.web.bind.annotation.ExceptionHandler
     public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+
+        log.warn("validation", e);
+
         String errorMessage = e.getConstraintViolations().stream()
                 .map(constraintViolation -> constraintViolation.getMessage())
                 .findFirst()
                 .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
-
         return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY,request);
     }
 
@@ -39,18 +48,26 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
         Map<String, String> errors = new LinkedHashMap<>();
 
-        e.getBindingResult().getFieldErrors().stream()
-                .forEach(fieldError -> {
-                    String fieldName = fieldError.getField();
-                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
-                    errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
-                });
+        // FieldErrors 처리
+        e.getBindingResult().getFieldErrors().forEach(fieldError -> {
+            String fieldName = fieldError.getField();
+            String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+            errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+        });
+
+        // GlobalErrors 처리
+        e.getBindingResult().getGlobalErrors().forEach(globalError -> {
+            String objectName = globalError.getObjectName();
+            String errorMessage = Optional.ofNullable(globalError.getDefaultMessage()).orElse("");
+            errors.merge(objectName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+        });
 
         return handleExceptionInternalArgs(e,HttpHeaders.EMPTY,ErrorStatus.valueOf("_BAD_REQUEST"),request,errors);
     }
 
     @org.springframework.web.bind.annotation.ExceptionHandler
     public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+
         e.printStackTrace();
 
         return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(),request, e.getMessage());

--- a/src/main/java/com/umc/DutchTogether/global/validation/annotation/ExistMeeting.java
+++ b/src/main/java/com/umc/DutchTogether/global/validation/annotation/ExistMeeting.java
@@ -1,0 +1,17 @@
+package com.umc.DutchTogether.global.validation.annotation;
+
+import com.umc.DutchTogether.global.validation.validator.ExistMeetingValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = {ExistMeetingValidator.class})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistMeeting {
+    String message() default "해당 모임이 존재하지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/umc/DutchTogether/global/validation/annotation/ValidateMeeting.java
+++ b/src/main/java/com/umc/DutchTogether/global/validation/annotation/ValidateMeeting.java
@@ -1,6 +1,6 @@
-package com.umc.DutchTogether.domain.meeting.validation.annotation;
+package com.umc.DutchTogether.global.validation.annotation;
 
-import com.umc.DutchTogether.domain.meeting.validation.validator.MeetingExistValidator;
+import com.umc.DutchTogether.global.validation.validator.MeetingValidator;
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 
@@ -8,10 +8,10 @@ import java.lang.annotation.*;
 
 // 아이디와 패스워드를 검증하는 Annotation
 @Documented
-@Constraint(validatedBy = {MeetingExistValidator.class})
+@Constraint(validatedBy = {MeetingValidator.class})
 @Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface ExistMeeting {
+public @interface ValidateMeeting {
     String message() default "ID,PW가 없습니다.";
     Class<?>[] groups() default {};
     Class<? extends Payload>[] payload() default {};

--- a/src/main/java/com/umc/DutchTogether/global/validation/annotation/ValidatePassword.java
+++ b/src/main/java/com/umc/DutchTogether/global/validation/annotation/ValidatePassword.java
@@ -1,6 +1,6 @@
-package com.umc.DutchTogether.domain.meeting.validation.annotation;
+package com.umc.DutchTogether.global.validation.annotation;
 
-import com.umc.DutchTogether.domain.meeting.validation.validator.PasswordValidator;
+import com.umc.DutchTogether.global.validation.validator.PasswordValidator;
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 

--- a/src/main/java/com/umc/DutchTogether/global/validation/validator/ExistMeetingValidator.java
+++ b/src/main/java/com/umc/DutchTogether/global/validation/validator/ExistMeetingValidator.java
@@ -1,0 +1,35 @@
+package com.umc.DutchTogether.global.validation.validator;
+
+import com.umc.DutchTogether.domain.meeting.entity.Meeting;
+import com.umc.DutchTogether.domain.meeting.repository.MeetingRepository;
+import com.umc.DutchTogether.global.validation.annotation.ExistMeeting;
+import com.umc.DutchTogether.global.apiPayload.code.status.ErrorStatus;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class ExistMeetingValidator implements ConstraintValidator<ExistMeeting, Long> {
+
+    private final MeetingRepository meetingRepository;
+
+    @Override
+    public void initialize(ExistMeeting constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long meetingNum, ConstraintValidatorContext constraintValidatorContext) {
+        Optional<Meeting> meeting = meetingRepository.findById(meetingNum);
+        if (meeting.isEmpty()) {
+            constraintValidatorContext.disableDefaultConstraintViolation();
+            constraintValidatorContext.buildConstraintViolationWithTemplate(ErrorStatus.MEETING_NOT_FOUND.toString()).addConstraintViolation();
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/umc/DutchTogether/global/validation/validator/MeetingValidator.java
+++ b/src/main/java/com/umc/DutchTogether/global/validation/validator/MeetingValidator.java
@@ -1,7 +1,7 @@
-package com.umc.DutchTogether.domain.meeting.validation.validator;
+package com.umc.DutchTogether.global.validation.validator;
 
 import com.umc.DutchTogether.domain.meeting.dto.MeetingRequest;
-import com.umc.DutchTogether.domain.meeting.validation.annotation.ExistMeeting;
+import com.umc.DutchTogether.global.validation.annotation.ValidateMeeting;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import lombok.RequiredArgsConstructor;
@@ -9,10 +9,10 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class MeetingExistValidator implements ConstraintValidator<ExistMeeting, MeetingRequest.MeetingDT0> {
+public class MeetingValidator implements ConstraintValidator<ValidateMeeting, MeetingRequest.MeetingDT0> {
 
     @Override
-    public void initialize(ExistMeeting constraintAnnotation) {
+    public void initialize(ValidateMeeting constraintAnnotation) {
     }
 
     @Override
@@ -51,8 +51,8 @@ public class MeetingExistValidator implements ConstraintValidator<ExistMeeting, 
         // ID 존재하지 않는 경우, 비밀번호 저장하지 않습니다.
         if ((meetingId.isBlank()) && (!password.isBlank())) {
             constraintValidatorContext.disableDefaultConstraintViolation();
-            constraintValidatorContext.buildConstraintViolationWithTemplate("비밀번호는 저장되지 않습니다.")
-                    .addPropertyNode("password")
+            constraintValidatorContext.buildConstraintViolationWithTemplate("아이디를 입력해주세요.")
+                    .addPropertyNode("meetingId")
                     .addConstraintViolation();
             return false;
         }

--- a/src/main/java/com/umc/DutchTogether/global/validation/validator/PasswordValidator.java
+++ b/src/main/java/com/umc/DutchTogether/global/validation/validator/PasswordValidator.java
@@ -1,6 +1,6 @@
-package com.umc.DutchTogether.domain.meeting.validation.validator;
+package com.umc.DutchTogether.global.validation.validator;
 
-import com.umc.DutchTogether.domain.meeting.validation.annotation.ValidatePassword;
+import com.umc.DutchTogether.global.validation.annotation.ValidatePassword;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 


### PR DESCRIPTION
👷‍♂️ 수정사항
-
<br>

- 서비스 단에서 수행하던 검증을 어노테이션으로 옮김 
  - 중복되는 코드가 감소

- validation 패키지를 global로 이동
- 서비스, 컨버터 역할분리..?
   - 서비스에서 객체를 찾는 메소드가 있으면 전체 메소드를 반환하고, 필요한 dto로 변환하는 건 컨버터에서 수행
   - 서비스와 컨버터의 역할 분리에서 현재 방식과 이전 방식 중 어떤 것이 더 적절한 지 의견주세요..!
