### PR TITLE
[REFACTOR] Payer 생성 관련

### DIFF
--- a/src/main/java/com/umc/DutchTogether/domain/payer/dto/PayerRequest.java
+++ b/src/main/java/com/umc/DutchTogether/domain/payer/dto/PayerRequest.java
@@ -19,7 +19,10 @@ public class PayerRequest {
     @Schema(title = "결제자 생성 요청 DTO")
     public static class PayerListDTO {
         @NotNull
-        private List<PayerDTO> payers;    }
+        private List<PayerDTO> payers;
+
+        private Long meetingNum;
+    }
 
     @Builder
     @Getter

--- a/src/main/java/com/umc/DutchTogether/domain/payer/repository/PayerRepository.java
+++ b/src/main/java/com/umc/DutchTogether/domain/payer/repository/PayerRepository.java
@@ -8,5 +8,6 @@ import java.util.List;
 
 @Repository
 public interface PayerRepository extends JpaRepository<Payer, Long> {
-        List<Payer> findByNameContainingIgnoreCase(String name);
+        boolean existsByNameAndAccountNumAndBank(String name, Long accountNum, String bank);
+
 }

--- a/src/main/java/com/umc/DutchTogether/domain/payer/repository/PayerRepository.java
+++ b/src/main/java/com/umc/DutchTogether/domain/payer/repository/PayerRepository.java
@@ -5,9 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PayerRepository extends JpaRepository<Payer, Long> {
-        boolean existsByNameAndAccountNumAndBank(String name, Long accountNum, String bank);
-
+      Optional<Payer> findByNameAndAccountNumAndBank(String name, Long accountNum, String bank);
 }


### PR DESCRIPTION
👷 추가 및 수정 
-

- /api/payers API의 request body에 meetingNum 추가
- 해당 meetingNum과 payerId를 바탕으로 정산하기 생성
- payer 생성 전 중복 체크