### PR TITLE
[FEAT] 정산현황 로그인 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,6 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
-	implementation 'io.springfox:springfox-swagger2:2.9.2'
-	implementation 'io.springfox:springfox-swagger-ui:2.9.2'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -34,6 +31,17 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'org.json:json:20210307'
+
+	// springdoc-openapi 라이브러리
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	//spring security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/umc/DutchTogether/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/umc/DutchTogether/domain/meeting/repository/MeetingRepository.java
@@ -9,5 +9,6 @@ import java.util.Optional;
 @Repository
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     Optional<Meeting> findByLink(String link);
+    Optional<Meeting> findByMeetingIdAndPassword(String meetingId, String password);
 }
 

--- a/src/main/java/com/umc/DutchTogether/domain/settlementStatus/controller/SettlementStatusRestController.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlementStatus/controller/SettlementStatusRestController.java
@@ -1,9 +1,12 @@
 package com.umc.DutchTogether.domain.settlementStatus.controller;
 
+import com.umc.DutchTogether.domain.settlementStatus.dto.SettlementStatusRequest;
 import com.umc.DutchTogether.domain.settlementStatus.dto.SettlementStatusResponse;
+import com.umc.DutchTogether.domain.settlementStatus.service.SettlementStatusCommandService;
 import com.umc.DutchTogether.domain.settlementStatus.service.SettlementStatusQueryService;
 import com.umc.DutchTogether.global.apiPayload.ApiResponse;
 import com.umc.DutchTogether.global.validation.annotation.ExistMeeting;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +18,13 @@ import org.springframework.web.bind.annotation.*;
 public class SettlementStatusRestController {
 
     private final SettlementStatusQueryService settlementStatusQueryService;
+    private final SettlementStatusCommandService settlementStatusCommandService;
+
+    @PostMapping("/login")
+    public ApiResponse<SettlementStatusResponse.SettlementStatusLoginDTO> login(@Valid @RequestBody SettlementStatusRequest.SettlementStatusDTO request) {
+        SettlementStatusResponse.SettlementStatusLoginDTO status = settlementStatusCommandService.login(request);
+        return ApiResponse.onSuccess(status);
+    }
 
     @GetMapping("/{meetingNum}")
     public ApiResponse<SettlementStatusResponse.SettlementStatusDTO> getSettlementStatus(@ExistMeeting @PathVariable Long meetingNum) {

--- a/src/main/java/com/umc/DutchTogether/domain/settlementStatus/converter/SettlementStatusConverter.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlementStatus/converter/SettlementStatusConverter.java
@@ -10,6 +10,14 @@ import com.umc.DutchTogether.domain.settler.entity.Settler;
 import java.util.List;
 
 public class SettlementStatusConverter {
+
+    public static SettlementStatusResponse.SettlementStatusLoginDTO toLoginResultDTO(Long meetingNum, String token) {
+        return SettlementStatusResponse.SettlementStatusLoginDTO.builder()
+                .meetingNum(meetingNum)
+                .token(token)
+                .build();
+    }
+
     public static SettlementStatusResponse.SettlementStatusDTO toSettlementStatusDTO(Settlement settlement, SettlementStatus settlementStatus , Meeting meeting, Payer payer, List<SettlementStatusResponse.SettlementSettlersDTO> settlersDTOList){
         return SettlementStatusResponse.SettlementStatusDTO.builder()
                 .meetingName(meeting.getName())

--- a/src/main/java/com/umc/DutchTogether/domain/settlementStatus/dto/SettlementStatusRequest.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlementStatus/dto/SettlementStatusRequest.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 public class SettlementStatusRequest {
+
     @Builder
     @Getter
     @NoArgsConstructor
@@ -16,6 +17,7 @@ public class SettlementStatusRequest {
         private String meetingId;
         private String password;
     }
+
     @Builder
     @Getter
     @NoArgsConstructor

--- a/src/main/java/com/umc/DutchTogether/domain/settlementStatus/dto/SettlementStatusResponse.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlementStatus/dto/SettlementStatusResponse.java
@@ -17,6 +17,16 @@ public class SettlementStatusResponse {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(title = "정산 현황 로그인 응답 DTO")
+    public static class SettlementStatusLoginDTO{
+        private Long meetingNum;
+        private String token;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     @Schema(title = "정산 현황 응답 DTO")
     public static class SettlementStatusDTO{
         private String meetingName;

--- a/src/main/java/com/umc/DutchTogether/domain/settlementStatus/dto/Token.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlementStatus/dto/Token.java
@@ -1,0 +1,14 @@
+package com.umc.DutchTogether.domain.settlementStatus.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class Token {
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public class TokenDTO {
+        private String token;
+    }
+}

--- a/src/main/java/com/umc/DutchTogether/domain/settlementStatus/service/SettlementStatusCommandService.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlementStatus/service/SettlementStatusCommandService.java
@@ -9,5 +9,6 @@ import com.umc.DutchTogether.domain.settlementStatus.entity.SettlementStatus;
 import java.util.Optional;
 
 public interface SettlementStatusCommandService {
+    public SettlementStatusResponse.SettlementStatusLoginDTO login(SettlementStatusRequest.SettlementStatusDTO request);
     public void addSettler(Long statusId, String settlerName);
 }

--- a/src/main/java/com/umc/DutchTogether/domain/settlementStatus/service/SettlementStatusCommandServiceImpl.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlementStatus/service/SettlementStatusCommandServiceImpl.java
@@ -1,19 +1,28 @@
 package com.umc.DutchTogether.domain.settlementStatus.service;
 
+import com.umc.DutchTogether.domain.meeting.entity.Meeting;
+import com.umc.DutchTogether.domain.meeting.repository.MeetingRepository;
 import com.umc.DutchTogether.domain.settlement.entity.Settlement;
 import com.umc.DutchTogether.domain.settlementSettler.entity.SettlementSettler;
 import com.umc.DutchTogether.domain.settlementStatus.converter.SettlementStatusConverter;
+import com.umc.DutchTogether.domain.settlementStatus.dto.SettlementStatusRequest;
 import com.umc.DutchTogether.domain.settlementStatus.dto.SettlementStatusResponse;
 import com.umc.DutchTogether.domain.settlementStatus.entity.SettlementStatus;
 import com.umc.DutchTogether.domain.settlementStatus.respoistory.SettlementStatusRepository;
 import com.umc.DutchTogether.domain.settler.entity.Settler;
 import com.umc.DutchTogether.domain.settler.repository.SettlerRepository;
+import com.umc.DutchTogether.global.apiPayload.code.status.ErrorStatus;
+import com.umc.DutchTogether.global.apiPayload.exception.handler.SettlementHandler;
+import com.umc.DutchTogether.global.security.TokenProvider;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
+
+import static com.umc.DutchTogether.global.apiPayload.code.status.ErrorStatus.MEETING_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +32,23 @@ public class SettlementStatusCommandServiceImpl implements SettlementStatusComma
 
     private final SettlementStatusRepository settlementStatusRepository;
     private final SettlerRepository settlerRepository;
+    private final MeetingRepository meetingRepository;
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public SettlementStatusResponse.SettlementStatusLoginDTO login(SettlementStatusRequest.SettlementStatusDTO request) {
+
+        Optional<Meeting> meetingOptional = meetingRepository.findByMeetingIdAndPassword(request.getMeetingId(), request.getPassword());
+        if (!meetingOptional.isPresent()) {
+             new SettlementHandler(ErrorStatus.MEETING_NOT_FOUND);
+        }
+
+        Meeting meeting = meetingOptional.get();
+        String token = tokenProvider.createToken(meeting);
+
+        return SettlementStatusConverter.toLoginResultDTO(meeting.getId(), token);
+    }
+
     @Override
     public void addSettler(Long statusId, String settlerName) {
         SettlementStatus settlementStatus = settlementStatusRepository.findById(statusId)

--- a/src/main/java/com/umc/DutchTogether/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/DutchTogether/global/apiPayload/code/status/ErrorStatus.java
@@ -25,7 +25,12 @@ public enum ErrorStatus implements BaseErrorCode {
     SETTLEMENT_NOT_FOUND_ID(HttpStatus.NOT_FOUND,"SETTLEMENT4004","settlement ID를 찾을 수 없습니다."),
 
     // 결제자 관련 에러
-    Payer_NOT_FOUND_BY_SETTLEMENTID(HttpStatus.NOT_FOUND,"PAYER4004","Payer를 찾을 수 없습니다.");
+    Payer_NOT_FOUND_BY_SETTLEMENTID(HttpStatus.NOT_FOUND,"PAYER4004","Payer를 찾을 수 없습니다."),
+
+    // 결제자 관련 에러
+    SETTLEMENT_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND,"PAYER4004","정산 현황을 찾을 수 없습니다.");
+
+
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/com/umc/DutchTogether/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/DutchTogether/global/config/SecurityConfig.java
@@ -1,0 +1,52 @@
+package com.umc.DutchTogether.global.config;
+
+import com.umc.DutchTogether.global.security.JwtFilter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+@EnableWebSecurity
+@Slf4j
+public class SecurityConfig {
+
+    @Autowired
+    private JwtFilter jwtFilter;
+
+    @Bean
+    protected SecurityFilterChain filterChain(HttpSecurity http) {
+        try {
+            http.csrf(AbstractHttpConfigurer::disable)
+                    .httpBasic(AbstractHttpConfigurer::disable)
+                    .cors(Customizer.withDefaults())
+                    .sessionManagement(sessionManagement ->
+                            sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                    )
+                    .authorizeHttpRequests(authorizeRequests ->
+                            authorizeRequests
+                                    .requestMatchers("/api/settlementStatus/login").permitAll()
+                                    .requestMatchers("/api/settlementStatus/*").authenticated() // /api/settlementStatus/* 경로는 인증 필요
+                                    .anyRequest().permitAll() // 다른 모든 요청은 인증 없이 접근 가능
+                    );
+
+            http.addFilterAfter(
+                    jwtFilter,
+                    CorsFilter.class
+            );
+
+            return http.build();
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/main/java/com/umc/DutchTogether/global/security/JwtFilter.java
+++ b/src/main/java/com/umc/DutchTogether/global/security/JwtFilter.java
@@ -1,0 +1,68 @@
+package com.umc.DutchTogether.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class JwtFilter extends OncePerRequestFilter {
+    @Autowired
+    private TokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        try {
+            String token = parseBearerToken(request);
+            log.info("Filter is running...");
+
+            if(token != null && !token.equalsIgnoreCase("null")) {
+                String userId = tokenProvider.validateAndGetUserId(token);
+                log.info("Authenticated user ID: " + userId);
+
+                AbstractAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        userId,
+                        null,
+                        AuthorityUtils.NO_AUTHORITIES
+                );
+                authentication.setDetails(new WebAuthenticationDetailsSource()
+                        .buildDetails(request));
+                SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+                securityContext.setAuthentication(authentication);
+                SecurityContextHolder.setContext(securityContext);
+            }
+
+
+        } catch (Exception ex) {
+            logger.error("Could not set user authentication in security context", ex);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String parseBearerToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+
+        if(StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/umc/DutchTogether/global/security/JwtToken.java
+++ b/src/main/java/com/umc/DutchTogether/global/security/JwtToken.java
@@ -1,0 +1,14 @@
+package com.umc.DutchTogether.global.security;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+@AllArgsConstructor
+public class JwtToken {
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/umc/DutchTogether/global/security/TokenProvider.java
+++ b/src/main/java/com/umc/DutchTogether/global/security/TokenProvider.java
@@ -1,0 +1,41 @@
+package com.umc.DutchTogether.global.security;
+
+import com.umc.DutchTogether.domain.meeting.entity.Meeting;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+@Slf4j
+@Service
+public class TokenProvider {
+
+    private final SecretKey secretKey = Keys.secretKeyFor(SignatureAlgorithm.HS512);
+
+    public String createToken(Meeting meeting) {
+        Date expiryDate = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+        return Jwts.builder()
+                .signWith(secretKey)  // 생성된 비밀 키로 서명
+                .setSubject(meeting.getMeetingId().toString())
+                .setIssuer("demo app")
+                .setIssuedAt(new Date())
+                .setExpiration(expiryDate)
+                .compact();
+    }
+
+    public String validateAndGetUserId(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.getSubject();
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용

- JWT 토큰 인증 방식으로 정산현황 로그인 API 구현

- 로그인시 응답으로 오는 토큰을 request header에 넣으면 정산현황 확인 가능
