### PR TITLE
[REFACTOR] 아이디 중복 처리, 정산현황 응답 수정

### DIFF
--- a/src/main/java/com/umc/DutchTogether/domain/meeting/dto/MeetingRequest.java
+++ b/src/main/java/com/umc/DutchTogether/domain/meeting/dto/MeetingRequest.java
@@ -1,5 +1,6 @@
 package com.umc.DutchTogether.domain.meeting.dto;
 
+import com.umc.DutchTogether.global.validation.annotation.UniqueMeeting;
 import com.umc.DutchTogether.global.validation.annotation.ValidateMeeting;
 import com.umc.DutchTogether.global.validation.annotation.ValidatePassword;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -16,6 +17,7 @@ public class MeetingRequest {
     @NoArgsConstructor
     @AllArgsConstructor
     @ValidateMeeting
+    @UniqueMeeting
     @Schema(title = "모임 생성 요청 DTO")
     public static class MeetingDT0{
         private String meetingId;

--- a/src/main/java/com/umc/DutchTogether/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/umc/DutchTogether/domain/meeting/repository/MeetingRepository.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 @Repository
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+    boolean existsByMeetingId(String meetingId);
     Optional<Meeting> findByLink(String link);
     Optional<Meeting> findByMeetingIdAndPassword(String meetingId, String password);
 }

--- a/src/main/java/com/umc/DutchTogether/domain/settlement/service/SettlementCommandServiceImpl.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlement/service/SettlementCommandServiceImpl.java
@@ -73,6 +73,11 @@ public class SettlementCommandServiceImpl implements SettlementCommandService {
             settlement.setTotalAmount(dto.getTotalAmount());
 
             settlementRepository.save(settlement);
+
+            SettlementStatus settlementStatus = SettlementStatus.builder()
+                    .settlement(settlement)
+                    .build();
+            settlementStatusRepository.save(settlementStatus);
         });
 
         return true;

--- a/src/main/java/com/umc/DutchTogether/domain/settlementSettler/service/SettlementSettlerCommandServiceImpl.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlementSettler/service/SettlementSettlerCommandServiceImpl.java
@@ -43,6 +43,7 @@ public class SettlementSettlerCommandServiceImpl implements SettlementSettlerCom
                 .orElseGet(() -> SettlementSettler.builder()
                         .settlement(settlement)
                         .settler(settler)
+                        .status(Status.COMPLETED)
                         .build());
         settlementSettlerRepository.save(settlementSettler);
         return SettlementSettlerConverter.toSettlementSettlerResultDTO(settlementSettler);

--- a/src/main/java/com/umc/DutchTogether/domain/settlementStatus/converter/SettlementStatusConverter.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlementStatus/converter/SettlementStatusConverter.java
@@ -18,19 +18,30 @@ public class SettlementStatusConverter {
                 .build();
     }
 
-    public static SettlementStatusResponse.SettlementStatusDTO toSettlementStatusDTO(Settlement settlement, SettlementStatus settlementStatus , Meeting meeting, Payer payer, List<SettlementStatusResponse.SettlementSettlersDTO> settlersDTOList){
+    public static SettlementStatusResponse.SettlementStatusDTO toSettlementStatusDTO(Meeting meeting, List<SettlementStatusResponse.SettlementListDTO> settlementDTOList){
         return SettlementStatusResponse.SettlementStatusDTO.builder()
                 .meetingName(meeting.getName())
-                .payer(payer.getName())
-                .completedNum(settlementStatus.getCompletedPeople())
+                .settlementListDTO(settlementDTOList)
+                .build();
+    }
+
+    public static SettlementStatusResponse.SettlementListDTO toSettlementListDTO(Settlement settlement, List<SettlementStatusResponse.SettlementSettlersDTO> settlersDTOList){
+        Payer payer = settlement.getPayer();
+
+        int completedNum = settlersDTOList.size();
+
+        return SettlementStatusResponse.SettlementListDTO.builder()
+                .settlementId(settlement.getId())
                 .numPeople(settlement.getNumPeople())
-                .settlementStatusDTOList(settlersDTOList)
+                .completedNum(completedNum)
+                .payer(payer.getName())
+                .completedSettler(settlersDTOList)
                 .build();
     }
 
     public static SettlementStatusResponse.SettlementSettlersDTO settlementSettlersDTO(Settler settler){
         return SettlementStatusResponse.SettlementSettlersDTO.builder()
-                .updateAt(settler.getUpdatedAt())
+                .settlementTime(settler.getUpdatedAt())
                 .name(settler.getName())
                 .build();
     }

--- a/src/main/java/com/umc/DutchTogether/domain/settlementStatus/dto/SettlementStatusResponse.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlementStatus/dto/SettlementStatusResponse.java
@@ -1,13 +1,11 @@
 package com.umc.DutchTogether.domain.settlementStatus.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -30,10 +28,20 @@ public class SettlementStatusResponse {
     @Schema(title = "정산 현황 응답 DTO")
     public static class SettlementStatusDTO{
         private String meetingName;
-        private String payer;
-        private int completedNum;
+        private List<SettlementListDTO> settlementListDTO;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(title = "정산 DTO")
+    public static class SettlementListDTO {
+        private Long settlementId;
         private int numPeople;
-        private List<SettlementSettlersDTO> settlementStatusDTOList;
+        private int completedNum;
+        private String payer;
+        private List<SettlementSettlersDTO> completedSettler;
     }
 
     @Builder
@@ -43,6 +51,6 @@ public class SettlementStatusResponse {
     @Schema(title = "정산자 DTO")
     public static class SettlementSettlersDTO {
         private String name;
-        private LocalDateTime updateAt;
+        private LocalDateTime settlementTime;
     }
 }

--- a/src/main/java/com/umc/DutchTogether/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/DutchTogether/global/apiPayload/code/status/ErrorStatus.java
@@ -20,6 +20,7 @@ public enum ErrorStatus implements BaseErrorCode {
     MEETING_NOT_VALID_ID(HttpStatus.UNAUTHORIZED, "MEETING4001", "ID를 다시 입력해주세요."),
     MEETING_NOT_VALID_PW(HttpStatus.UNAUTHORIZED, "MEETING4001", "비밀번호를 다시 입력해주세요."),
     MEETING_NOT_FOUND(HttpStatus.BAD_REQUEST,"MEETING4002","모임이 존재하지 않습니다."),
+    MEETING_ALREADY_EXISTS(HttpStatus.BAD_REQUEST,"MEETING4002","해당 아이디가 이미 존재합니다."),
 
     // 정산하기 관련 에러
     SETTLEMENT_NOT_FOUND_ID(HttpStatus.NOT_FOUND,"SETTLEMENT4004","settlement ID를 찾을 수 없습니다."),
@@ -29,8 +30,8 @@ public enum ErrorStatus implements BaseErrorCode {
     // 결제자 관련 에러
     Payer_NOT_FOUND_BY_SETTLEMENTID(HttpStatus.NOT_FOUND,"PAYER4004","Payer를 찾을 수 없습니다."),
 
-    // 결제자 관련 에러
-    SETTLEMENT_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND,"PAYER4004","정산 현황을 찾을 수 없습니다.");
+    // 정산현황 관련 에러
+    SETTLEMENT_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND,"SETTLEMENTSTATUS4004","정산 현황을 찾을 수 없습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/umc/DutchTogether/global/security/TokenProvider.java
+++ b/src/main/java/com/umc/DutchTogether/global/security/TokenProvider.java
@@ -21,6 +21,7 @@ public class TokenProvider {
 
     public String createToken(Meeting meeting) {
         Date expiryDate = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+        log.info("Creating token for meeting ID: {}", meeting.getMeetingId());
         return Jwts.builder()
                 .signWith(secretKey)  // 생성된 비밀 키로 서명
                 .setSubject(meeting.getMeetingId().toString())
@@ -31,11 +32,16 @@ public class TokenProvider {
     }
 
     public String validateAndGetUserId(String token) {
-        Claims claims = Jwts.parserBuilder()
-                .setSigningKey(secretKey)
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
-        return claims.getSubject();
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            return claims.getSubject();
+        } catch (Exception e) {
+            log.error("JWT validation failed: {}", e.getMessage());
+            throw new RuntimeException("Invalid JWT token");
+        }
     }
 }

--- a/src/main/java/com/umc/DutchTogether/global/validation/annotation/UniqueMeeting.java
+++ b/src/main/java/com/umc/DutchTogether/global/validation/annotation/UniqueMeeting.java
@@ -1,0 +1,17 @@
+package com.umc.DutchTogether.global.validation.annotation;
+
+import com.umc.DutchTogether.global.validation.validator.UniqueMeetingValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = {UniqueMeetingValidator.class})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UniqueMeeting {
+    String message() default "해당 아이디가 이미 존재합니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/umc/DutchTogether/global/validation/validator/UniqueMeetingValidator.java
+++ b/src/main/java/com/umc/DutchTogether/global/validation/validator/UniqueMeetingValidator.java
@@ -1,0 +1,36 @@
+package com.umc.DutchTogether.global.validation.validator;
+
+import com.umc.DutchTogether.domain.meeting.dto.MeetingRequest;
+import com.umc.DutchTogether.domain.meeting.repository.MeetingRepository;
+import com.umc.DutchTogether.global.apiPayload.code.status.ErrorStatus;
+import com.umc.DutchTogether.global.validation.annotation.UniqueMeeting;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UniqueMeetingValidator implements ConstraintValidator<UniqueMeeting, MeetingRequest.MeetingDT0> {
+
+    private final MeetingRepository meetingRepository;
+
+    @Override
+    public void initialize(UniqueMeeting constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(MeetingRequest.MeetingDT0 meetingDTO, ConstraintValidatorContext constraintValidatorContext) {
+        boolean meetingExists = meetingRepository.existsByMeetingId(meetingDTO.getMeetingId());
+
+        if (meetingExists) {
+            constraintValidatorContext.disableDefaultConstraintViolation();
+            constraintValidatorContext.buildConstraintViolationWithTemplate(ErrorStatus.MEETING_ALREADY_EXISTS.getMessage())
+                    .addConstraintViolation();
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용

- 모임 아이디 중복 처리, 정산현황 응답 수정

- 정산현황에서 meetingNum을 파라미터로 넘길 경우, 해당 모임에 있는 정산이 모두 보이도록 함