### PR TITLE
[REFACTOR] 모임 생성에서 모임 이름 저장 분리

### DIFF
--- a/src/main/java/com/umc/DutchTogether/domain/meeting/controller/MeetingRestController.java
+++ b/src/main/java/com/umc/DutchTogether/domain/meeting/controller/MeetingRestController.java
@@ -21,8 +21,14 @@ public class MeetingRestController {
     private final MeetingQueryService meetingQueryService;
 
     @PostMapping("/")
-    public ApiResponse<MeetingResponse.MeetingDT0> createMeeting(@Valid @RequestBody MeetingRequest.MeetingDT0 request){
+    public ApiResponse<MeetingResponse.MeetingResultDT0> createMeeting(@Valid @RequestBody MeetingRequest.MeetingDT0 request){
         Meeting meeting = meetingCommandService.createMeeting(request);
+        return ApiResponse.onSuccess(MeetingConverter.toMeetingResultDTO(meeting));
+    }
+
+    @PutMapping("/meetingName")
+    public ApiResponse<MeetingResponse.MeetingResultDT0> putMeetingName(@Valid @RequestBody MeetingRequest.PutMeetingNameDT0 request){
+        Meeting meeting = meetingCommandService.updateMeetingName(request);
         return ApiResponse.onSuccess(MeetingConverter.toMeetingResultDTO(meeting));
     }
 

--- a/src/main/java/com/umc/DutchTogether/domain/meeting/converter/MeetingConverter.java
+++ b/src/main/java/com/umc/DutchTogether/domain/meeting/converter/MeetingConverter.java
@@ -13,14 +13,14 @@ public class MeetingConverter {
         return Meeting.builder()
                 .meetingId(requestBody.getMeetingId())
                 .password(requestBody.getPassword())
-                .name(requestBody.getName())
                 .build();
     }
-    public static MeetingResponse.MeetingDT0 toMeetingResultDTO(Meeting meeting) {
+
+    public static MeetingResponse.MeetingResultDT0 toMeetingResultDTO(Meeting meeting) {
         if (meeting == null) {
             return null;
         }
-        return MeetingResponse.MeetingDT0.builder()
+        return MeetingResponse.MeetingResultDT0.builder()
                 .meetingNum(meeting.getId())
                 .build();
     }

--- a/src/main/java/com/umc/DutchTogether/domain/meeting/dto/MeetingRequest.java
+++ b/src/main/java/com/umc/DutchTogether/domain/meeting/dto/MeetingRequest.java
@@ -23,7 +23,16 @@ public class MeetingRequest {
         private String meetingId;
         @ValidatePassword
         private String password;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(title = "모임 이름 put 요청 DTO")
+    public static class PutMeetingNameDT0{
+        private Long meetingNum;
         @NotNull(message = "모임 이름을 입력해주세요")
-        private String name;
+        private String meetingName;
     }
 }

--- a/src/main/java/com/umc/DutchTogether/domain/meeting/dto/MeetingResponse.java
+++ b/src/main/java/com/umc/DutchTogether/domain/meeting/dto/MeetingResponse.java
@@ -13,7 +13,7 @@ public class MeetingResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     @Schema(title = "모임 생성 응답 DTO")
-    public static class MeetingDT0 {
+    public static class MeetingResultDT0 {
         private Long meetingNum;
     }
 

--- a/src/main/java/com/umc/DutchTogether/domain/meeting/service/MeetingCommandService.java
+++ b/src/main/java/com/umc/DutchTogether/domain/meeting/service/MeetingCommandService.java
@@ -5,4 +5,5 @@ import com.umc.DutchTogether.domain.meeting.entity.Meeting;
 
 public interface MeetingCommandService {
     public Meeting createMeeting(MeetingRequest.MeetingDT0 request);
+    public Meeting updateMeetingName(MeetingRequest.PutMeetingNameDT0 request);
 }

--- a/src/main/java/com/umc/DutchTogether/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/umc/DutchTogether/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -35,6 +35,24 @@ public class MeetingCommandServiceImpl implements MeetingCommandService{
         return meetingRepository.save(newMeeting);
     }
 
+    @Override
+    public Meeting updateMeetingName(MeetingRequest.PutMeetingNameDT0 request) {
+        Meeting existingMeeting = meetingRepository.findById(request.getMeetingNum())
+                .orElse(null);
+
+        if (existingMeeting == null) {
+            existingMeeting = Meeting.builder()
+                    .name(request.getMeetingName())
+                    .link(generateLink())
+                    .build();
+        } else {
+            // Meeting이 있을 경우 이름만 업데이트
+            existingMeeting.setName(request.getMeetingName());
+        }
+
+        return meetingRepository.save(existingMeeting);
+    }
+
     private String generateLink() {
         return UUID.randomUUID().toString().substring(0, 8);
     }


### PR DESCRIPTION
## 🔎 작업 내용

- 모임 생성에서 아이디, 패스워드 저장과 모임 이름 저장 분리

- 모임이 존재할 경우, 모임 이름 변경 / 모임이 존재하지 않을 경우, 모임 생성
