### PR TITLE
[FEAT][FIX] 여러명 정산하기 settlement 생성 관련

### DIFF
--- a/src/main/java/com/umc/DutchTogether/domain/payer/repository/PayerRepository.java
+++ b/src/main/java/com/umc/DutchTogether/domain/payer/repository/PayerRepository.java
@@ -12,4 +12,5 @@ import java.util.Optional;
 public interface PayerRepository extends JpaRepository<Payer, Long> {
 
       List<Payer> findAllByName(String name);
+      Optional<Payer> findByName(String name);
 }

--- a/src/main/java/com/umc/DutchTogether/domain/payer/service/PayerCommandService.java
+++ b/src/main/java/com/umc/DutchTogether/domain/payer/service/PayerCommandService.java
@@ -2,9 +2,10 @@ package com.umc.DutchTogether.domain.payer.service;
 
 import com.umc.DutchTogether.domain.payer.dto.PayerRequest;
 import com.umc.DutchTogether.domain.payer.dto.PayerResponse;
+import com.umc.DutchTogether.domain.payer.entity.Payer;
 
 public interface PayerCommandService {
     public PayerResponse.PayerListDTO updatePayer(PayerRequest.PayerListDTO request);
-
+    public Long createSettlement(Payer payer, Long meetingNum);
     public PayerResponse.PayerListDTO createPayer(PayerRequest.PayerNameListDTO request);
 }

--- a/src/main/java/com/umc/DutchTogether/domain/payer/service/PayerCommandServiceImpl.java
+++ b/src/main/java/com/umc/DutchTogether/domain/payer/service/PayerCommandServiceImpl.java
@@ -68,15 +68,15 @@ public class PayerCommandServiceImpl implements PayerCommandService{
         List<PayerResponse.PayerDTO> payerResponse = payers.stream()
                 .map(payerDTO->{
                     Payer payer = PayerConverter.toPayer(payerDTO);
-                    Optional<Payer> existPayer = checkPayer(payer,meetingNum);
-                    //결제자가 2명인 경우
-                    if (existPayer.isPresent()) {
-                        //정산하기만 추가적으로 생성, 결제자는 1명으로 유지
-                        createSettlement(existPayer.get(), request.getMeetingNum());
-                        return null;
-                    }
+//                    Optional<Payer> existPayer = checkPayer(payer,meetingNum);
+//                    //결제자가 2명인 경우
+//                    if (existPayer.isPresent()) {
+//                        //정산하기만 추가적으로 생성, 결제자는 1명으로 유지
+//                        createSettlement(existPayer.get(), request.getMeetingNum());
+//                        return null;
+//                    }
                     Payer savedPayer = saveNewPayer(payer);
-                    createSettlement(savedPayer,request.getMeetingNum());
+//                    createSettlement(savedPayer,request.getMeetingNum());
                     return PayerConverter.toPayerDTO(savedPayer);
                 })
                 .filter(Objects::nonNull) // null 값을 필터링하여 제거
@@ -84,13 +84,15 @@ public class PayerCommandServiceImpl implements PayerCommandService{
         return PayerConverter.payerListDTO(payerResponse);
     }
 
+    @Override
     //정산하기 생성 메소드
-    private void createSettlement(Payer payer, Long meetingNum) {
+    public Long createSettlement(Payer payer, Long meetingNum) {
         Meeting meeting = meetingRepository.findById(meetingNum)
                 .orElseThrow(() -> new MeetingHandler(MEETING_NOT_FOUND));
         Settlement settlement = SettlementConverter.toSettlement(payer,meeting);
         try {
             settlementRepository.save(settlement);
+            return settlement.getId();
         } catch (Exception e) {
             throw new RuntimeException("Settlement 저장에 실패 했습니다.", e);
         }

--- a/src/main/java/com/umc/DutchTogether/domain/settlement/controller/SettlementRestController.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlement/controller/SettlementRestController.java
@@ -3,6 +3,7 @@ package com.umc.DutchTogether.domain.settlement.controller;
 import com.umc.DutchTogether.domain.settlement.dto.*;
 import com.umc.DutchTogether.domain.settlement.service.SettlementCommandService;
 import com.umc.DutchTogether.global.apiPayload.ApiResponse;
+import io.swagger.annotations.Api;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -17,7 +18,7 @@ public class SettlementRestController {
 
     @PostMapping("/single")
     public ApiResponse<SettlementResponse.SettlementDTO> createSingleSettlement(@RequestBody @Valid SettlementRequest.SettlementDTO request) {
-        SettlementResponse.SettlementDTO settlement = settlementCommandService.CreateSingleSettlement(request);
+        SettlementResponse.SettlementDTO settlement = settlementCommandService.createSingleSettlement(request);
         return ApiResponse.onSuccess(settlement);
     }
 
@@ -25,5 +26,10 @@ public class SettlementRestController {
     public ApiResponse<Boolean> updateSettlement(@RequestBody @Valid SettlementRequest.SettlementInfoListDTO request){
         Boolean result = settlementCommandService.updateSettlement(request);
         return ApiResponse.onSuccess(result);
+    }
+
+    @PostMapping("/Multi/")
+    public ApiResponse<SettlementResponse.SettlementDTO> createMultiSettlement(@RequestBody SettlementRequest.SettlementIdDTO request){
+        return ApiResponse.onSuccess(null);
     }
 }

--- a/src/main/java/com/umc/DutchTogether/domain/settlement/controller/SettlementRestController.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlement/controller/SettlementRestController.java
@@ -29,7 +29,8 @@ public class SettlementRestController {
     }
 
     @PostMapping("/Multi/")
-    public ApiResponse<SettlementResponse.SettlementDTO> createMultiSettlement(@RequestBody SettlementRequest.SettlementIdDTO request){
-        return ApiResponse.onSuccess(null);
+    public ApiResponse<SettlementResponse.SettlementDTO> createMultiSettlement(@RequestBody SettlementRequest.SettlementPayerDTO request){
+        SettlementResponse.SettlementDTO result = settlementCommandService.createMultipleSettlement(request);
+        return ApiResponse.onSuccess(result);
     }
 }

--- a/src/main/java/com/umc/DutchTogether/domain/settlement/converter/SettlementConverter.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlement/converter/SettlementConverter.java
@@ -2,8 +2,11 @@ package com.umc.DutchTogether.domain.settlement.converter;
 
 import com.umc.DutchTogether.domain.meeting.entity.Meeting;
 import com.umc.DutchTogether.domain.payer.entity.Payer;
+import com.umc.DutchTogether.domain.receipt.entity.Receipt;
+import com.umc.DutchTogether.domain.settlement.dto.SettlementRequest;
 import com.umc.DutchTogether.domain.settlement.dto.SettlementResponse;
 import com.umc.DutchTogether.domain.settlement.entity.Settlement;
+import com.umc.DutchTogether.domain.settlementStatus.entity.SettlementStatus;
 
 public class SettlementConverter {
 
@@ -17,6 +20,30 @@ public class SettlementConverter {
         return Settlement.builder()
                 .meeting(meeting)
                 .payer(payer)
+                .build();
+    }
+
+    public static Payer toPayer(SettlementRequest.SettlementDTO request) {
+        return Payer.builder()
+                .name(request.getPayer())
+                .accountNum(request.getAccountNumber())
+                .bank(request.getBankName())
+                .build();
+    }
+
+    public static Settlement toSettlement(SettlementRequest.SettlementDTO request,Meeting meeting ,Payer payer, Receipt receipt) {
+        return Settlement.builder()
+                .meeting(meeting)
+                .payer(payer)
+                .totalAmount(request.getTotalAmount())
+                .numPeople(request.getNumPeople())
+                .receipt(receipt)
+                .build();
+    }
+
+    public static SettlementStatus toSettlementStatus(Settlement settlement){
+        return SettlementStatus.builder()
+                .settlement(settlement)
                 .build();
     }
 }

--- a/src/main/java/com/umc/DutchTogether/domain/settlement/converter/SettlementConverter.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlement/converter/SettlementConverter.java
@@ -46,4 +46,10 @@ public class SettlementConverter {
                 .settlement(settlement)
                 .build();
     }
+
+    public static SettlementResponse.SettlementDTO toSettlementDTO(Long settlementId){
+        return SettlementResponse.SettlementDTO.builder()
+                .settlementId(settlementId)
+                .build();
+    }
 }

--- a/src/main/java/com/umc/DutchTogether/domain/settlement/dto/SettlementRequest.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlement/dto/SettlementRequest.java
@@ -79,7 +79,10 @@ public class SettlementRequest {
     @NoArgsConstructor
     @AllArgsConstructor
     @Schema(title = "여러명 정산하기 - 정산하기 테이블 생성 요청 DTO")
-    public static class SettlementIdDTO{
+    public static class SettlementPayerDTO{
+        @NotNull
         private String PayerName;
+        @NotNull
+        private Long meetingNum;
     }
 }

--- a/src/main/java/com/umc/DutchTogether/domain/settlement/dto/SettlementRequest.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlement/dto/SettlementRequest.java
@@ -73,4 +73,13 @@ public class SettlementRequest {
         @ExistReceipt
         private Long receiptId;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(title = "여러명 정산하기 - 정산하기 테이블 생성 요청 DTO")
+    public static class SettlementIdDTO{
+        private String PayerName;
+    }
 }

--- a/src/main/java/com/umc/DutchTogether/domain/settlement/dto/SettlementResponse.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlement/dto/SettlementResponse.java
@@ -16,7 +16,6 @@ public class SettlementResponse {
         private Long settlementId;
     }
 
-    //바뀐 디자인에서 사용할지 안할지 모르겠음..
     @Builder
     @Getter
     @NoArgsConstructor

--- a/src/main/java/com/umc/DutchTogether/domain/settlement/service/SettlementCommandService.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlement/service/SettlementCommandService.java
@@ -9,5 +9,5 @@ public interface SettlementCommandService {
 
     public Boolean updateSettlement(SettlementRequest.SettlementInfoListDTO request);
 
-    public SettlementResponse.SettlementDTO createMultipleSettlement(SettlementRequest.SettlementIdDTO request);
+    public SettlementResponse.SettlementDTO createMultipleSettlement(SettlementRequest.SettlementPayerDTO request);
 }

--- a/src/main/java/com/umc/DutchTogether/domain/settlement/service/SettlementCommandService.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlement/service/SettlementCommandService.java
@@ -5,7 +5,9 @@ import com.umc.DutchTogether.domain.settlement.dto.SettlementResponse;
 
 public interface SettlementCommandService {
 
-    public SettlementResponse.SettlementDTO CreateSingleSettlement(SettlementRequest.SettlementDTO request);
+    public SettlementResponse.SettlementDTO createSingleSettlement(SettlementRequest.SettlementDTO request);
 
     public Boolean updateSettlement(SettlementRequest.SettlementInfoListDTO request);
+
+    public SettlementResponse.SettlementDTO createMultipleSettlement(SettlementRequest.SettlementIdDTO request);
 }

--- a/src/main/java/com/umc/DutchTogether/domain/settlement/service/SettlementCommandServiceImpl.java
+++ b/src/main/java/com/umc/DutchTogether/domain/settlement/service/SettlementCommandServiceImpl.java
@@ -36,7 +36,7 @@ public class SettlementCommandServiceImpl implements SettlementCommandService {
     private final ReceiptRepository receiptRepository;
 
     @Override
-    public SettlementResponse.SettlementDTO CreateSingleSettlement(SettlementRequest.SettlementDTO request) {
+    public SettlementResponse.SettlementDTO createSingleSettlement(SettlementRequest.SettlementDTO request) {
         Optional<Meeting> meeting = meetingRepository.findById(request.getMeetingNum());
         Receipt receipt = null;
         if (request.getReceiptId() != null) {
@@ -92,6 +92,11 @@ public class SettlementCommandServiceImpl implements SettlementCommandService {
         });
 
         return true;
+    }
+
+    @Override
+    public SettlementResponse.SettlementDTO createMultipleSettlement(SettlementRequest.SettlementIdDTO request) {
+        return null;
     }
 
 }


### PR DESCRIPTION
<h2>✨기능 변경 사항</h2>

<h3>기존 방식</h3>
<p>
    기존에는 <strong>payer(결제자) 이름 입력</strong> 시, 각 <em>settlement(정산)</em>이 생성됨. 
    이로 인해, 동일한 payer가 여러 개의 settlement를 가진 경우, 동일한 이름의 payer를 
    여러 번 입력해야 하는 단점이 있음.
</p>

<h3>변경된 방식</h3>
<p>
    이제 <strong>payer 이름을 입력</strong>하면 payer 테이블에 객체만 생성. 
    이후, 다음 화면에서 <strong>셀렉트 박스</strong>를 통해 payer를 선택할 때 
    settlement 생성.
</p>

<h3>개선된 사항</h3>
<ul>
    <li>payer가 여러 개의 settlement를 가진 경우에도 payer 이름을 입력 창에서 한 번만 입력하면됨.</li>
    <li>동명이인 처리도 자연스럽게 해결.</li>
</ul>